### PR TITLE
For multiples of three print “Fizz” instead of the number.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Logs
 logs
 *.log

--- a/src/gen/FizzBuzzGen.ts
+++ b/src/gen/FizzBuzzGen.ts
@@ -2,8 +2,11 @@ import { Singleton } from "typescript-ioc";
 
 @Singleton
 export class FizzBuzzGen {
-    // return a string , we have to return Fizz and Buzz very soon
     generate(num: number): string {
-        return num.toString();
+        if (num % 3 === 0) {
+            return "Fizz";
+          } else {
+            return num.toString();
+        }
     }
 }

--- a/tests/FizzBuzzGen.spec.ts
+++ b/tests/FizzBuzzGen.spec.ts
@@ -8,4 +8,10 @@ describe("FizzBuzzGen", () => {
     expect(fizzBuzzGen.generate(10)).to.equal("10");
     expect(fizzBuzzGen.generate(100)).to.equal("100");
   });
+  it("For multiples of three print “Fizz” instead of the number.", () => {
+    const fizzBuzzGen = new FizzBuzzGen();
+    expect(fizzBuzzGen.generate(3)).to.equal("Fizz");
+    expect(fizzBuzzGen.generate(6)).to.equal("Fizz");
+    expect(fizzBuzzGen.generate(9)).to.equal("Fizz");
+  });
 });


### PR DESCRIPTION
- For multiples of three print “Fizz” instead of the number.
- Added new test cases cover new path