### PR TITLE
For multiples of five print “Buzz” instead of the number.

### DIFF
--- a/.yml
+++ b/.yml
@@ -1,2 +1,0 @@
-- name: Code Coverage Summary
-  uses: irongut/CodeCoverageSummary@v1.3.0

--- a/src/gen/FizzBuzzGen.ts
+++ b/src/gen/FizzBuzzGen.ts
@@ -5,7 +5,10 @@ export class FizzBuzzGen {
     generate(num: number): string {
         if (num % 3 === 0) {
             return "Fizz";
-          } else {
+          } else if (num % 5 === 0) {
+            return "Buzz";
+          }
+          else {
             return num.toString();
         }
     }

--- a/tests/FizzBuzzGen.spec.ts
+++ b/tests/FizzBuzzGen.spec.ts
@@ -2,16 +2,24 @@ import { FizzBuzzGen } from "../src/gen/FizzBuzzGen";
 import { expect } from "chai";
 
 describe("FizzBuzzGen", () => {
-  it("should return string of the provided number", () => {
+  it("should return string of the provided number where number is not multiple of 3 or 5", () => {
     const fizzBuzzGen = new FizzBuzzGen();
     expect(fizzBuzzGen.generate(1)).to.equal("1");
-    expect(fizzBuzzGen.generate(10)).to.equal("10");
-    expect(fizzBuzzGen.generate(100)).to.equal("100");
+    expect(fizzBuzzGen.generate(3)).to.not.equal("3");
+    expect(fizzBuzzGen.generate(100)).to.not.equal("100");
   });
+
   it("For multiples of three print “Fizz” instead of the number.", () => {
     const fizzBuzzGen = new FizzBuzzGen();
     expect(fizzBuzzGen.generate(3)).to.equal("Fizz");
     expect(fizzBuzzGen.generate(6)).to.equal("Fizz");
     expect(fizzBuzzGen.generate(9)).to.equal("Fizz");
+  });
+
+  it("For multiples of five print “Buzz” instead of the number.", () => {
+    const fizzBuzzGen = new FizzBuzzGen();
+    expect(fizzBuzzGen.generate(5)).to.equal("Buzz");
+    expect(fizzBuzzGen.generate(10)).to.equal("Buzz");
+    expect(fizzBuzzGen.generate(20)).to.equal("Buzz");
   });
 });


### PR DESCRIPTION
- For multiples of five print “Buzz” instead of the number.